### PR TITLE
Add minor transform threshold

### DIFF
--- a/scanmatcher/src/scanmatcher_component.cpp
+++ b/scanmatcher/src/scanmatcher_component.cpp
@@ -331,14 +331,20 @@ void ScanMatcherComponent::receiveCloud(
   Eigen::Matrix4f sim_trans = getTransformation(current_pose_stamped_.pose);
 
   if (use_odom_) {
-    geometry_msgs::msg::TransformStamped odom_trans;
-    try {
-      odom_trans = tfbuffer_.lookupTransform(
-        odom_frame_id_, robot_frame_id_, tf2_ros::fromMsg(
-          stamp));
-    } catch (tf2::TransformException & e) {
-      RCLCPP_ERROR(this->get_logger(), "%s", e.what());
-    }
+      geometry_msgs::msg::TransformStamped odom_trans;
+      try {
+        rclcpp::Duration tolerance = rclcpp::Duration::from_seconds(0.2);
+        rclcpp::Time lookup_time = stamp - tolerance;
+
+        odom_trans = tfbuffer_.lookupTransform(
+            odom_frame_id_, robot_frame_id_,
+            tf2_ros::fromMsg(lookup_time),
+            tf2::durationFromSec(0.5));
+      }
+      catch (tf2::TransformException &e) {
+        RCLCPP_WARN(this->get_logger(), "Odom TF error: %s", e.what());
+        return;
+      }
     Eigen::Affine3d odom_affine = tf2::transformToEigen(odom_trans);
     Eigen::Matrix4f odom_mat = odom_affine.matrix().cast<float>();
     if (previous_odom_mat_ != Eigen::Matrix4f::Identity()) {


### PR DESCRIPTION
Hi,

I've observed that when using the default configuration (i.e., without IMU or odometry), the generated TF tree is incorrect. When odometry is enabled, the TF tree becomes structurally correct, but synchronization issues during transform lookups still cause the path to be inaccurate.

The updated TF configuration addresses this problem. I've attached the new TF tree along with a demonstration video showing how the system performs with both IMU and odometry inputs using EasyNav. Please note that the map elevation is not very detailed, as this was a quick prototype.

[Video](https://youtu.be/hvPmGKW1UgA)

Best, 
Esther
<img width="1920" height="1200" alt="Screenshot from 2025-07-21 21-45-47" src="https://github.com/user-attachments/assets/213ecad3-2e20-4cce-bab0-94c729eaea42" />
